### PR TITLE
Temporarily remove cloudflare image cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "unngoy-frontend",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/src/lib/components/AssetCard.svelte
+++ b/src/lib/components/AssetCard.svelte
@@ -18,11 +18,7 @@
 			<a href={assetUrl} class="">
 				<img
 					class="asset-image"
-					src={asset?.thumbnailUrl
-						? import.meta.env.MODE === 'production'
-							? `/cdn-cgi/image/format=auto,fit=scale-down,width=560/${asset.thumbnailUrl}`
-							: asset.thumbnailUrl
-						: '/placeholder.webp'}
+					src={asset?.thumbnailUrl ? asset.thumbnailUrl : '/placeholder.webp'}
 					alt="thumbnail"
 				/>
 			</a>


### PR DESCRIPTION
Cloudflare image cdn hit max usage and images were not falling back to the og url